### PR TITLE
Organize Voltaire campaign docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,14 @@
+# Repo Guide
+
+This repository focuses on creative writing and planning material for a D&D campaign. It isn't a traditional codebase, though scripts may appear to help organize content.
+
+## Directory Overview
+- `VDD.json` records an AI brainstorming session about Voltaire.
+- `dm/` contains campaign notes like character lore and episode ideas.
+
+## Contribution Guidelines
+- Prioritize surreal horror mixed with dark humor.
+- Keep entries concise and in Markdown.
+- Code snippets are allowed if they enhance storytelling or automation.
+
+There are no automated tests yet, so skip running test commands.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,14 +1,122 @@
-# Repo Guide
+# Voltaire Repo — **Bootstrap Agent**
 
-This repository focuses on creative writing and planning material for a D&D campaign. It isn't a traditional codebase, though scripts may appear to help organize content.
+> *“Reality is my playground, rules are just polite suggestions.”* — Voltaire the Black
 
-## Directory Overview
-- `VDD.json` records an AI brainstorming session about Voltaire.
-- `dm/` contains campaign notes like character lore and episode ideas.
+---
 
-## Contribution Guidelines
-- Prioritize surreal horror mixed with dark humor.
-- Keep entries concise and in Markdown.
-- Code snippets are allowed if they enhance storytelling or automation.
+## 1 · Why this agent exists
 
-There are no automated tests yet, so skip running test commands.
+The Bootstrap Agent is a lightweight, single‑file Python worker whose only job is to **take the chaotic brainstorming history in `VDD.json` and convert it into an organized repo** ready for episode design. Think of it as the repo’s groundskeeper: it tidies up the raw ideas, files them where they belong, and locks the gate behind it once there’s nothing left to sweep.
+
+---
+
+## 2 · Tech stack & constraints
+
+| Layer        | Choice                                            | Notes                                                             |
+| ------------ | ------------------------------------------------- | ----------------------------------------------------------------- |
+| Language     | **Python 3.12**                                   | Standard library only.                                            |
+| LLM          | **OpenAI Codex (`gpt‑4o` or better)**             | Used *inside* the agent for text → structure prompts.             |
+| I/O          | Local FS                                          | No RPC, no network calls beyond the OpenAI API.                   |
+| Package deps | `json`, `pathlib`, `shutil`, `datetime`, `openai` | First four are stdlib; `openai` is the only external requirement. |
+
+> **No other dependencies.** If you need something exotic, generate it with Codex on the fly.
+
+---
+
+## 3 · Folder layout (after bootstrap)
+
+```
+/                # repo root
+├─ AGENTS.md     # ← this file
+├─ VDD.json      # brainstorming dump (shrinks then disappears)
+├─ archive/      # original JSON slices
+│   └─ 2025‑05‑30‑bootstrap‑slice‑01.json
+├─ character/
+│   ├─ voltaire.md          # final, human‑readable bio & stats
+│   └─ traits.json          # machine‑readable attributes
+└─ dm/
+    ├─ 00‑index.md          # how to DM inside Voltaire’s mind
+    ├─ story‑graph.yaml     # nodes & contingencies
+    └─ encounters/
+        └─ arena‑of‑eyes.yaml
+```
+
+---
+
+## 4 · Agent algorithm (pseudo)
+
+```text
+1. Load VDD.json → data
+2. For each conversation segment:
+   ▸ Identify blocks: backstory · stats · desires · quirks · lore seeds
+   ▸ Ask Codex to transform each block into:
+       a. Markdown (readable)
+       b. JSON/YAML (structured)
+3. Write outputs into /character or /dm as appropriate
+4. Move the raw segment into /archive/ with timestamped filename
+5. Delete the segment from in‑memory data object
+6. Repeat until VDD.json → []
+7. Write the trimmed data back to VDD.json
+8. If VDD.json is now empty → delete the file
+9. Commit changes (optional: auto‑git if repo is initialised)
+```
+
+### Idempotency
+
+The agent can be run multiple times; it skips segments already archived (filename hash check).
+
+---
+
+## 5 · Key parsing heuristics
+
+| Heuristic              | Description                                      |
+| ---------------------- | ------------------------------------------------ |
+| `###` headings         | Treat as new **section blocks**.                 |
+| `HP`, `AC`, `PB` regex | Capture stat lines into `traits.json`.           |
+| First‑person voice     | Likely *journal entries* → send to `/dm/lore/…`. |
+| Imperative verbs       | Potential **quest hooks**.                       |
+
+Codex prompt examples live in `prompts/` if you want to tweak them later.
+
+---
+
+## 6 · Finishing Stage 1
+
+Stage 1 is done when:
+
+* `/character/voltaire.md` exists and looks presentable.
+* `/dm/00‑index.md` has a high‑level episode outline.
+* `VDD.json` no longer exists in the root.
+
+The CI check `ci/stage‑1‑complete.sh` enforces these.
+
+---
+
+## 7 · Next steps (Stage 2 preview)
+
+Once the Bootstrap Agent self‑destructs:
+
+1. Design **scene generators** (Codex + YAML templates) inside `/dm/encounters/`.
+2. Flesh out **NPC files** in `/dm/npc/` with similar agent helpers.
+3. Implement a **random‑weirdness oracle** for on‑the‑fly surprises.
+
+---
+
+## 8 · Running the agent
+
+```bash
+pip install openai
+python agents/bootstrap_agent.py  # default assumes OPENAI_API_KEY is set
+```
+
+For debugging, pass `--dry‑run` to skip writes.
+
+---
+
+## 9 · License
+
+MIT for code, Creative Commons BY‑SA 4.0 for narrative content.
+
+---
+
+Happy chaos‑crafting!

--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
-# voltaire
+# Voltaire D&D Repository
+
+This repository collects all information about the character **Voltaire** and the surreal world inside his mind.
+
+* `VDD.json` – a conversational log with an AI brainstorming Voltaire's history and the tone of an adventure.
+* `dm/` – planning material for a D&D campaign based on those ideas.
+
+The goal is to document Voltaire's backstory, goals and strange powers, then craft an episodic campaign full of bizarre encounters and creepy horror fun.
+

--- a/dm/README.md
+++ b/dm/README.md
@@ -1,0 +1,12 @@
+# Voltaire's Mindscape Campaign
+
+This folder will hold notes and episode outlines for a horror-themed adventure set inside Voltaire's mind. The ideas are drawn from the conversation in `../VDD.json`.
+
+## Current Outline
+
+1. **Setting** – The party is dragged into Voltaire's warped mental realm where reality behaves like a grotesque pop-up book.
+2. **Goal** – Escape the labyrinth of Voltaire's memories and nightmares while piecing together his motives and powers.
+3. **Tone** – Surreal horror with dark humor. Use elements like skin-bound books, bizarre libraries and unsettling nursery scenes.
+
+Future documents will expand on Voltaire's backstory, key NPCs and episodic scenarios.
+

--- a/dm/voltaire_character.md
+++ b/dm/voltaire_character.md
@@ -1,0 +1,11 @@
+# Voltaire
+
+A mysterious figure who once transcribed both the **Book of Vile Darkness** and the **Book of Exalted Deeds** under the influence of a potion of haste. The process left him forever altered:
+
+- **Universal Understanding** – Voltaire can read and write every language intuitively, though he does so unconsciously.
+- **Arcane Tattoos** – His body is covered in strange markings. His eyes never close and it physically hurts when he frowns, leaving him with a constant unsettling smile.
+- **Crab Book** – A bizarre tome that consumes the skin of creatures and absorbs lingering memories.
+- **Allies & Foes** – He has ties to a wizard named Greg, demons, and the goddess Shar. One party member is even married to Shar.
+
+Voltaire's mind is a labyrinth of horror imagery, from crawling crabs and ink-stained pages to warped Fae creatures. The party must delve into this mindscape to uncover his desires and the mysteries surrounding his past.
+


### PR DESCRIPTION
## Summary
- expand README with repo overview
- add `dm/` folder for the upcoming D&D campaign
- describe Voltaire's mindscape adventure outline
- summarize Voltaire's character traits
- add repo guidelines

## Testing
- no tests available